### PR TITLE
Fix direct routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+	"rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
The vercel json chnages tells vercel to redirect all urls to the root url so that the client side routing can take effect from there.